### PR TITLE
Update span-lite and fix missing iterator include for latest CMake version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 compile_commands.json
 .clangd/
 issues/
+.vscode/

--- a/include/poker/dealer.hpp
+++ b/include/poker/dealer.hpp
@@ -5,6 +5,7 @@
 #include <bitset>
 #include <climits>
 #include <new>
+#include <iterator>
 
 #include <poker/community_cards.hpp>
 #include <poker/deck.hpp>

--- a/include/poker/detail/span.hpp
+++ b/include/poker/detail/span.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #define span_FEATURE_MEMBER_BACK_FRONT 1
-#define span_CONFIG_INDEX_TYPE std::size_t
+#define span_CONFIG_SIZE_TYPE std::size_t
 #include <nonstd/span.hpp>
 
 namespace poker {


### PR DESCRIPTION
This PR updates the project to use the most recent versions of CMake and span-lite.